### PR TITLE
Add Nette\Security\IIdentity in universalObjectCratesClasses

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -5,6 +5,7 @@ parameters:
 		- Nette\Database\IRow
 		- Nette\Http\SessionSection
 		- Nette\Security\Identity
+		- Nette\Security\IIdentity
 	earlyTerminatingMethodCalls:
 		Nette\Application\UI\Presenter:
 			- redirect


### PR DESCRIPTION
```
/** @var Nette\Security\User $user */
$user = ..
$identity = $user->getIdentity()->name; // Access to an undefined property Nette\Security\IIdentity::$name
```
Problem is that `getIdentity()` returns `Nette\Security\IIdentity` as you can see here https://api.nette.org/2.4/source-Security.User.php.html#126