### PR TITLE
PHP 7.2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 php:
   - 7.0
+  - 7.1
+  - 7.2
 before_script:
   - composer self-update
   - composer install

--- a/src/Reflection/Nette/NetteObjectClassReflectionExtension.php
+++ b/src/Reflection/Nette/NetteObjectClassReflectionExtension.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\Reflection\Nette;
 
-use Nette\Object;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
@@ -14,7 +13,7 @@ class NetteObjectClassReflectionExtension implements MethodsClassReflectionExten
 
 	public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
 	{
-		if (!$classReflection->isSubclassOf(Object::class)) {
+		if (!$classReflection->isSubclassOf('Nette\Object')) {
 			return false;
 		}
 
@@ -58,7 +57,7 @@ class NetteObjectClassReflectionExtension implements MethodsClassReflectionExten
 	public function hasMethod(ClassReflection $classReflection, string $methodName): bool
 	{
 		$traitNames = $this->getTraitNames($classReflection->getNativeReflection());
-		if (!$classReflection->isSubclassOf(Object::class) && !in_array(\Nette\SmartObject::class, $traitNames, true)) {
+		if (!$classReflection->isSubclassOf('Nette\Object') && !in_array(\Nette\SmartObject::class, $traitNames, true)) {
 			return false;
 		}
 

--- a/src/Rule/Nette/DoNotExtendNetteObjectRule.php
+++ b/src/Rule/Nette/DoNotExtendNetteObjectRule.php
@@ -43,12 +43,12 @@ class DoNotExtendNetteObjectRule implements \PHPStan\Rules\Rule
 		}
 
 		$classReflection = $this->broker->getClass($className);
-		if ($classReflection->isSubclassOf(\Nette\Object::class)) {
+		if ($classReflection->isSubclassOf('Nette\Object')) {
 			return [
 				sprintf(
 					"Class %s extends %s - it's better to use %s trait.",
 					$className,
-					\Nette\Object::class,
+					'Nette\Object',
 					\Nette\SmartObject::class
 				),
 			];


### PR DESCRIPTION
Fixes #8 

It's ugly, but it works... The only way I could get the tests pass under PHP 7.2 was to use string to refer to `Nette\Object`. Using alias or FQN does not work, because it triggers autoloading during static analysis and an error is thrown due to the `Nette\Object` code.