### PR TITLE
PHP 7.2 compatibility vol.2

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,4 +4,5 @@ parameters:
 
 	ignoreErrors:
 		- '#PHPUnit_Framework_MockObject_MockObject given#'
+		- '# but returns PHPUnit_Framework_MockObject_MockObject.#'
 		- '#Access to an undefined property PHPUnit_Framework_MockObject_MockObject::\$[a-zA-Z0-9_]+#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,7 @@
 parameters:
+	excludes_analyse:
+		- %rootDir%/../../../tests/notAutoloaded/*
+
 	ignoreErrors:
 		- '#PHPUnit_Framework_MockObject_MockObject given#'
+		- '#Access to an undefined property PHPUnit_Framework_MockObject_MockObject::\$[a-zA-Z0-9_]+#'

--- a/src/Reflection/Nette/NetteObjectClassReflectionExtension.php
+++ b/src/Reflection/Nette/NetteObjectClassReflectionExtension.php
@@ -13,7 +13,7 @@ class NetteObjectClassReflectionExtension implements MethodsClassReflectionExten
 
 	public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
 	{
-		if (!$classReflection->isSubclassOf('Nette\Object')) {
+		if (!$this->inheritsFromNetteObject($classReflection->getNativeReflection())) {
 			return false;
 		}
 
@@ -57,7 +57,7 @@ class NetteObjectClassReflectionExtension implements MethodsClassReflectionExten
 	public function hasMethod(ClassReflection $classReflection, string $methodName): bool
 	{
 		$traitNames = $this->getTraitNames($classReflection->getNativeReflection());
-		if (!$classReflection->isSubclassOf('Nette\Object') && !in_array(\Nette\SmartObject::class, $traitNames, true)) {
+		if (!in_array(\Nette\SmartObject::class, $traitNames, true) && !$this->inheritsFromNetteObject($classReflection->getNativeReflection())) {
 			return false;
 		}
 
@@ -86,6 +86,17 @@ class NetteObjectClassReflectionExtension implements MethodsClassReflectionExten
 		}
 
 		return $traitNames;
+	}
+
+	private function inheritsFromNetteObject(\ReflectionClass $class): bool
+	{
+		while (($parentClass = $class->getParentClass()) !== false) {
+			if ($parentClass->getName() === 'Nette\Object') {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 }

--- a/src/Rule/Nette/DoNotExtendNetteObjectRule.php
+++ b/src/Rule/Nette/DoNotExtendNetteObjectRule.php
@@ -43,7 +43,8 @@ class DoNotExtendNetteObjectRule implements \PHPStan\Rules\Rule
 		}
 
 		$classReflection = $this->broker->getClass($className);
-		if ($classReflection->isSubclassOf('Nette\Object')) {
+		$parentClass = $classReflection->getNativeReflection()->getParentClass();
+		if ($parentClass !== false && $parentClass->getName() === 'Nette\Object') {
 			return [
 				sprintf(
 					"Class %s extends %s - it's better to use %s trait.",

--- a/tests/Reflection/Nette/NetteObjectClassReflectionExtensionTest.php
+++ b/tests/Reflection/Nette/NetteObjectClassReflectionExtensionTest.php
@@ -1,0 +1,157 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\Nette;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\PropertyReflection;
+
+class NetteObjectClassReflectionExtensionTest extends \PHPUnit\Framework\TestCase
+{
+
+	/** @var \PHPStan\Reflection\Nette\NetteObjectClassReflectionExtension */
+	private $extension;
+
+	protected function setUp()
+	{
+		$this->extension = new NetteObjectClassReflectionExtension();
+	}
+
+	/**
+	 * @return mixed[]
+	 */
+	public function dataHasMethod(): array
+	{
+		$data = [];
+		$data[] = [
+			\PHPStan\Tests\SmartObjectChild::class,
+			'onPublicEvent',
+			true,
+		];
+		$data[] = [
+			\PHPStan\Tests\SmartObjectChild::class,
+			'onProtectedEvent',
+			false,
+		];
+		if (PHP_VERSION_ID < 70200) { // PHP 7.2 is incompatible with Nette\Object.
+			$data[] = [
+				'PHPStan\Tests\NetteObjectChild',
+				'onPublicEvent',
+				true,
+			];
+			$data[] = [
+				'PHPStan\Tests\NetteObjectChild',
+				'onProtectedEvent',
+				false,
+			];
+		}
+		return $data;
+	}
+
+	/**
+	 * @dataProvider dataHasMethod
+	 * @param string $className
+	 * @param string $method
+	 * @param bool $result
+	 */
+	public function testHasMethod(string $className, string $method, bool $result)
+	{
+		$classReflection = $this->mockClassReflection(new \ReflectionClass($className));
+		$this->assertSame($result, $this->extension->hasMethod($classReflection, $method));
+	}
+
+	/**
+	 * @return mixed[]
+	 */
+	public function dataHasProperty(): array
+	{
+		$data = [];
+		$data[] = [
+			\PHPStan\Tests\SmartObjectChild::class,
+			'foo',
+			false,
+		];
+		if (PHP_VERSION_ID < 70200) { // PHP 7.2 is incompatible with Nette\Object.
+			$data[] = [
+				'PHPStan\Tests\NetteObjectChild',
+				'staticProperty',
+				false,
+			];
+			$data[] = [
+				'PHPStan\Tests\NetteObjectChild',
+				'publicProperty',
+				true,
+			];
+			$data[] = [
+				'PHPStan\Tests\NetteObjectChild',
+				'protectedProperty',
+				false,
+			];
+		}
+		return $data;
+	}
+
+	/**
+	 * @dataProvider dataHasProperty
+	 * @param string $className
+	 * @param string $property
+	 * @param bool $result
+	 */
+	public function testHasProperty(string $className, string $property, bool $result)
+	{
+		$classReflection = $this->mockClassReflection(new \ReflectionClass($className));
+		$this->assertSame($result, $this->extension->hasProperty($classReflection, $property));
+	}
+
+	private function mockClassReflection(\ReflectionClass $class): ClassReflection
+	{
+		$classReflection = $this->createMock(ClassReflection::class);
+		$classReflection->method('getNativeReflection')->will($this->returnValue($class));
+		$classReflection->method('hasProperty')->will(
+			$this->returnCallback(
+				function (string $property) use ($class): bool {
+					return $class->hasProperty($property);
+				}
+			)
+		);
+		$classReflection->method('getProperty')->will(
+			$this->returnCallback(
+				function (string $property) use ($class): PropertyReflection {
+					return $this->mockPropertyReflection($class->getProperty($property));
+				}
+			)
+		);
+		$classReflection->method('hasMethod')->will(
+			$this->returnCallback(
+				function (string $method) use ($class): bool {
+					return $class->hasMethod($method);
+				}
+			)
+		);
+		$classReflection->method('getMethod')->will(
+			$this->returnCallback(
+				function (string $method) use ($class): MethodReflection {
+					return $this->mockMethodReflection($class->getMethod($method));
+				}
+			)
+		);
+
+		return $classReflection;
+	}
+
+	private function mockMethodReflection(\ReflectionMethod $method): MethodReflection
+	{
+		$methodReflection = $this->createMock(MethodReflection::class);
+		$methodReflection->method('isPublic')->will($this->returnValue($method->isPublic()));
+		$methodReflection->method('isStatic')->will($this->returnValue($method->isStatic()));
+		return $methodReflection;
+	}
+
+	private function mockPropertyReflection(\ReflectionProperty $property): PropertyReflection
+	{
+		$propertyReflection = $this->createMock(PropertyReflection::class);
+		$propertyReflection->method('isPublic')->will($this->returnValue($property->isPublic()));
+		return $propertyReflection;
+	}
+
+}

--- a/tests/Rule/Nette/DoNotExtendNetteObjectRuleTest.php
+++ b/tests/Rule/Nette/DoNotExtendNetteObjectRuleTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rule\Nette;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
+use PHPStan\Reflection\ClassReflection;
+
+class DoNotExtendNetteObjectRuleTest extends \PHPUnit\Framework\TestCase
+{
+
+	/** @var \PHPStan\Rule\Nette\DoNotExtendNetteObjectRule */
+	private $rule;
+
+	protected function setUp()
+	{
+		$broker = $this->createMock(Broker::class);
+		$broker->method('hasClass')->will($this->returnValue(true));
+		$broker->method('getClass')->will($this->returnCallback(function (string $className) {
+			$nativeReflection = new \ReflectionClass($className);
+			$classReflection = $this->createMock(ClassReflection::class);
+			$classReflection->method('getNativeReflection')->will($this->returnValue($nativeReflection));
+			return $classReflection;
+		}));
+
+		$this->rule = new DoNotExtendNetteObjectRule($broker);
+	}
+
+	public function testSmartObjectChild()
+	{
+		$scope = $this->createMock(Scope::class);
+		$node = $this->createMock(Node::class);
+		$node->namespacedName = 'PHPStan\Tests\SmartObjectChild';
+
+		$result = $this->rule->processNode($node, $scope);
+
+		$this->assertEmpty($result);
+	}
+
+	public function testNetteObjectChild()
+	{
+		if (PHP_VERSION_ID >= 70200) {
+			$this->markTestSkipped('PHP 7.2 is incompatible with Nette\Object.');
+		}
+		$scope = $this->createMock(Scope::class);
+		$node = $this->createMock(Node::class);
+		$node->namespacedName = 'PHPStan\Tests\NetteObjectChild';
+
+		$result = $this->rule->processNode($node, $scope);
+
+		$this->assertSame(['Class PHPStan\Tests\NetteObjectChild extends Nette\Object - it\'s better to use Nette\SmartObject trait.'], $result);
+	}
+
+}

--- a/tests/notAutoloaded/NetteObjectChild.php
+++ b/tests/notAutoloaded/NetteObjectChild.php
@@ -4,4 +4,25 @@ namespace PHPStan\Tests;
 class NetteObjectChild extends \Nette\Object
 {
 
+	/** @var callable[] */
+	public $onPublicEvent = [];
+
+	/** @var callable[] */
+	protected $onProtectedEvent = [];
+
+	public static function getStaticProperty(): string
+	{
+		return 'static';
+	}
+
+	public function getPublicProperty(): string
+	{
+		return 'public';
+	}
+
+	protected function getProtectedProperty(): string
+	{
+		return 'protected';
+	}
+
 }

--- a/tests/notAutoloaded/NetteObjectChild.php
+++ b/tests/notAutoloaded/NetteObjectChild.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+namespace PHPStan\Tests;
+
+class NetteObjectChild extends \Nette\Object
+{
+
+}

--- a/tests/notAutoloaded/SmartObjectChild.php
+++ b/tests/notAutoloaded/SmartObjectChild.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+namespace PHPStan\Tests;
+
+class SmartObjectChild
+{
+
+	use \Nette\SmartObject;
+
+}

--- a/tests/notAutoloaded/SmartObjectChild.php
+++ b/tests/notAutoloaded/SmartObjectChild.php
@@ -6,4 +6,10 @@ class SmartObjectChild
 
 	use \Nette\SmartObject;
 
+	/** @var callable[] */
+	public $onPublicEvent = [];
+
+	/** @var callable[] */
+	protected $onProtectedEvent = [];
+
 }


### PR DESCRIPTION
Regarding PHP 7.2 compatibility, it turns out #9 is not enough. Although the existing tests passed, you run into a problem when you actually execute the code of `DoNotExtendNetteObjectRule` or `NetteObjectClassReflectionExtension`, because `$reflection->isSubclassOf()` triggers the autoloading and it dies on PHP 7.2.
This PR solves the problem by:
- Adding tests for both classes, so the code is actually executed during travis build.
- Rewriting the code so that it avoids triggering autoloading of `Nette\Object`.
- There is a small BC break - `DoNotExtendNetteObjectRule` now checks only the direct parent of a class. But I consider this a bugfix - PHPStan should report problems with project code only, not problems with classes from 3rd party libs that are used and extended in the project.