### PR TITLE
Support for Nette Object method getter syntax

### DIFF
--- a/src/Reflection/Nette/NetteObjectClassReflectionExtension.php
+++ b/src/Reflection/Nette/NetteObjectClassReflectionExtension.php
@@ -7,6 +7,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Type\CallableType;
 
 class NetteObjectClassReflectionExtension implements MethodsClassReflectionExtension, PropertiesClassReflectionExtension
 {
@@ -15,6 +16,10 @@ class NetteObjectClassReflectionExtension implements MethodsClassReflectionExten
 	{
 		if (!$this->inheritsFromNetteObject($classReflection->getNativeReflection())) {
 			return false;
+		}
+
+		if ($classReflection->hasNativeMethod($propertyName)) {
+			return true;
 		}
 
 		$getterMethod = $this->getMethodByProperty($classReflection, $propertyName);
@@ -45,6 +50,10 @@ class NetteObjectClassReflectionExtension implements MethodsClassReflectionExten
 
 	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
 	{
+		if ($classReflection->hasNativeMethod($propertyName)) {
+			return new NetteObjectPropertyReflection($classReflection, new CallableType());
+		}
+
 		/** @var \PHPStan\Reflection\MethodReflection $getterMethod */
 		$getterMethod = $this->getMethodByProperty($classReflection, $propertyName);
 		return new NetteObjectPropertyReflection($classReflection, $getterMethod->getReturnType());

--- a/tests/Reflection/Nette/NetteObjectClassReflectionExtensionTest.php
+++ b/tests/Reflection/Nette/NetteObjectClassReflectionExtensionTest.php
@@ -87,6 +87,11 @@ class NetteObjectClassReflectionExtensionTest extends \PHPStan\Testing\TestCase
 				'protectedProperty',
 				false,
 			];
+			$data[] = [
+				'PHPStan\Tests\NetteObjectChild',
+				'methodAsClosureGetter',
+				true,
+			];
 		}
 		return $data;
 	}

--- a/tests/data/NetteObjectChild.php
+++ b/tests/data/NetteObjectChild.php
@@ -25,4 +25,9 @@ class NetteObjectChild extends \Nette\Object
 		return 'protected';
 	}
 
+	public function methodAsClosureGetter(): string
+	{
+		return 'methodAsClosureGetter';
+	}
+
 }


### PR DESCRIPTION
Nette Object supports (bit controversial) syntax to get closure of object method by `$object->method.` 

This PR prevents false positive errors "Access to an undefined property " if code uses this syntax.