### PR TITLE
Component::lookup nullable when $need=false

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This extension provides following features:
 * `Nette\ComponentModel\Container::getComponent()` knows type of the component because it reads the return type on `createComponent*` (this works best in presenters and controls)
 * `Nette\DI\Container::getByType` and `createInstance` return type based on first parameter (`Foo::class`).
 * `Nette\Forms\Container::getValues` return type based on `$asArray` parameter.
+* `Nette\ComponentModel\Component::lookup` return type based on `$throw` parameter.
 * Dynamic methods of [Nette\Utils\Html](https://doc.nette.org/en/2.4/html-elements)
 * Magic [Nette\Object and Nette\SmartObject](https://doc.nette.org/en/2.4/php-language-enhancements) properties
 * Event listeners through the `on*` properties

--- a/extension.neon
+++ b/extension.neon
@@ -34,6 +34,11 @@ services:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Nette\ComponentLookupDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Nette\FormsBaseControlDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/src/Type/Nette/ComponentLookupDynamicReturnTypeExtension.php
+++ b/src/Type/Nette/ComponentLookupDynamicReturnTypeExtension.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Nette;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+final class ComponentLookupDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return \Nette\ComponentModel\Component::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'lookup';
+	}
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+	{
+		if (count($methodCall->args) < 2) {
+			return $methodReflection->getReturnType();
+		}
+
+		$paramNeedExpr = $methodCall->args[1]->value;
+		$paramNeedType = $scope->getType($paramNeedExpr);
+
+		if ($paramNeedType instanceof ConstantBooleanType) {
+			if ($paramNeedType->getValue()) {
+				return TypeCombinator::removeNull($methodReflection->getReturnType());
+			}
+
+			return TypeCombinator::addNull($methodReflection->getReturnType());
+		}
+
+		return $methodReflection->getReturnType();
+	}
+
+}


### PR DESCRIPTION
Nette\ComponentModel\Component:lookup return type is based on second parameter ($need). When $need is false then return type is `IComponent|null`.

btw. I would to add feature to directly know return type based on first parameter `$class`. Is it possible to get it now? I know the case when `MyComponentClass::class` is passed... but when it is some function call (for which phpstan has extension for example), is it possible?