### PR TITLE
HtmlMethodReflection: magic getters return mixed

### DIFF
--- a/src/Reflection/Nette/HtmlMethodReflection.php
+++ b/src/Reflection/Nette/HtmlMethodReflection.php
@@ -6,6 +6,7 @@ use Nette\Utils\Html;
 use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
@@ -69,7 +70,7 @@ class HtmlMethodReflection implements MethodReflection
 
 	public function getReturnType(): Type
 	{
-		return new ObjectType(Html::class);
+		return substr($this->name, 0, 3) === 'get' ? new MixedType() : new ObjectType(Html::class);
 	}
 
 }


### PR DESCRIPTION
Hi,
there is one exception when calling magic method on Html object. They are getters, then return type is mixed - depends on previous setter on that attribute.

Example:
```php
$html = Html::el('span', ['class' => 'asdf']);
$html->getClass(); // returns string

$html->setClass(['ab', 'cd', 'ef']); // returns Html
$html->getClass(); // returns string[]
```