### PR TITLE
Presenter::getSession Return type extension

### DIFF
--- a/src/Type/Nette/PresenterGetSessionReturnTypeExtension
+++ b/src/Type/Nette/PresenterGetSessionReturnTypeExtension
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Nette;
+
+use Nette\Http\Session;
+use Nette\Http\SessionSection;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+final class PresenterGetSessionReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+	public function getClass(): string
+	{
+		return \Nette\Application\UI\Presenter::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'getSession';
+	}
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+	{
+		if (count($methodCall->args) === 0 || $scope->getType($methodCall->args[0]->value) instanceof NullType) {
+			return new ObjectType(Session::class);
+		}
+
+		return new ObjectType(SessionSection::class);
+	}
+}


### PR DESCRIPTION
Hi,
we can resolve returned type of `Nette\Application\UI\Presenter::getSession` method if we know passed argument `$namespace`. If argument is not specified or is null then it is whole Nette\Http\Session otherwise Nette\Http\SessionSection is returned.