### PR TITLE
UI\Component::getPresenter return type extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This extension provides following features:
 * `Nette\DI\Container::getByType` and `createInstance` return type based on first parameter (`Foo::class`).
 * `Nette\Forms\Container::getValues` return type based on `$asArray` parameter.
 * `Nette\ComponentModel\Component::lookup` return type based on `$throw` parameter.
+* `Nette\Application\UI\Component::getPresenter` return type based on `$throw` parameter.
 * Dynamic methods of [Nette\Utils\Html](https://doc.nette.org/en/2.4/html-elements)
 * Magic [Nette\Object and Nette\SmartObject](https://doc.nette.org/en/2.4/php-language-enhancements) properties
 * Event listeners through the `on*` properties

--- a/extension.neon
+++ b/extension.neon
@@ -39,6 +39,11 @@ services:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Nette\ComponentGetPresenterDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Nette\FormsBaseControlDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/src/Type/Nette/ComponentGetPresenterDynamicReturnTypeExtension.php
+++ b/src/Type/Nette/ComponentGetPresenterDynamicReturnTypeExtension.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Nette;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+final class ComponentGetPresenterDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return 'Nette\Application\UI\Component';
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'getPresenter';
+	}
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+	{
+		$defaultReturnType = ParametersAcceptorSelector::selectSingle(
+			$methodReflection->getVariants()
+		)->getReturnType();
+		if (count($methodCall->args) < 1) {
+			return $defaultReturnType;
+		}
+
+		$paramNeedExpr = $methodCall->args[0]->value;
+		$paramNeedType = $scope->getType($paramNeedExpr);
+
+		if ($paramNeedType instanceof ConstantBooleanType) {
+			if ($paramNeedType->getValue()) {
+				return TypeCombinator::removeNull($defaultReturnType);
+			}
+
+			return TypeCombinator::addNull($defaultReturnType);
+		}
+
+		return $defaultReturnType;
+	}
+
+}


### PR DESCRIPTION
Add support for dynamic return type based on `$throw` parameter of `Nette\Application\UI\Component::getPresenter()`.

This PR is heavily based on `ComponentLookupDynamicReturnTypeExtension`.