### PR TITLE
Fix: No need to update composer itself twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ php:
   - 7.1
   - 7.2
 before_script:
-  - composer self-update
   - composer install
 script:
   - vendor/bin/phing


### PR DESCRIPTION
This PR

* [x] stops updating `composer` itself twice on Travis