### PR TITLE
Added property events reflection extension for UI\Form

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -18,6 +18,11 @@ parameters:
 
 services:
 	-
+		class: PHPStan\Reflection\Nette\FormEventsReflectionExtension
+		tags:
+			- phpstan.broker.propertiesClassReflectionExtension
+
+	-
 		class: PHPStan\Reflection\Nette\HtmlClassReflectionExtension
 		tags:
 			- phpstan.broker.propertiesClassReflectionExtension

--- a/src/Reflection/Nette/FormEventsReflectionExtension.php
+++ b/src/Reflection/Nette/FormEventsReflectionExtension.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Reflection\Nette;
+
+use Nette\Application\UI\Form;
+use Nette\Utils\ArrayHash;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\Native\NativeParameterReflection;
+use PHPStan\Reflection\PassedByReference;
+use PHPStan\Reflection\PropertiesClassReflectionExtension;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\CallableType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\VoidType;
+
+final class FormEventsReflectionExtension implements PropertiesClassReflectionExtension
+{
+
+	/**
+	 * @var array<string, PropertyReflection>
+	 */
+	private $eventTypes;
+
+	private function initialize(ClassReflection $classReflection): bool
+	{
+		$this->eventTypes = [
+			'onSuccess' => self::createReflection(new CallableType([new NativeParameterReflection('form', false, new ObjectType(Form::class), PassedByReference::createNo(), false), new NativeParameterReflection('values', true, TypeCombinator::union(new ObjectType(ArrayHash::class), new ArrayType(new StringType(), new MixedType())), PassedByReference::createNo(), false)], new VoidType(), false), $classReflection),
+			'onError' => self::createReflection(new CallableType([new NativeParameterReflection('form', false, new ObjectType(Form::class), PassedByReference::createNo(), false)], new VoidType(), false), $classReflection),
+			'onSubmit' => self::createReflection(new CallableType([new NativeParameterReflection('form', false, new ObjectType(Form::class), PassedByReference::createNo(), false), new NativeParameterReflection('values', true, TypeCombinator::union(new ObjectType(ArrayHash::class), new ArrayType(new StringType(), new MixedType())), PassedByReference::createNo(), false)], new VoidType(), false), $classReflection),
+			'onRender' => self::createReflection(new CallableType([new NativeParameterReflection('form', false, new ObjectType(Form::class), PassedByReference::createNo(), false)], new VoidType(), false), $classReflection),
+			'onAttached' => self::createReflection(new CallableType([new NativeParameterReflection('form', false, new ObjectType(Form::class), PassedByReference::createNo(), false)], new VoidType(), false), $classReflection),
+		];
+
+		return true;
+	}
+
+	public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
+	{
+		return ($classReflection->isSubclassOf(Form::class) || $classReflection->getName() === Form::class)
+			&& $this->initialize($classReflection)
+			&& array_key_exists($propertyName, $this->eventTypes);
+	}
+
+	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
+	{
+		return $this->eventTypes[$propertyName];
+	}
+
+	private static function createReflection(Type $propertyType, ClassReflection $classReflection): PropertyReflection
+	{
+		return new class($propertyType, $classReflection) implements PropertyReflection
+		{
+			/** @var Type */
+			private $propertyType;
+
+			/** @var ClassReflection */
+			private $classReflection;
+
+			public function __construct(Type $propertyType, ClassReflection $classReflection)
+			{
+				$this->propertyType = $propertyType;
+				$this->classReflection = $classReflection;
+			}
+
+			public function getDeclaringClass(): ClassReflection
+			{
+				return $this->classReflection;
+			}
+
+			public function isStatic(): bool
+			{
+				return false;
+			}
+
+			public function isPrivate(): bool
+			{
+				return false;
+			}
+
+			public function isPublic(): bool
+			{
+				return true;
+			}
+
+			public function getType(): Type
+			{
+				return $this->propertyType;
+			}
+
+			public function isReadable(): bool
+			{
+				return true;
+			}
+
+			public function isWritable(): bool
+			{
+				return true;
+			}
+		};
+	}
+
+}

--- a/tests/Reflection/Nette/FormEventsReflectionExtensionTest.php
+++ b/tests/Reflection/Nette/FormEventsReflectionExtensionTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\Nette;
+
+use PHPStan\Type\VerbosityLevel;
+
+final class FormEventsReflectionExtensionTest extends \PHPStan\Testing\TestCase
+{
+
+	/** @var \PHPStan\Broker\Broker */
+	private $broker;
+
+	/** @var \PHPStan\Reflection\Nette\FormEventsReflectionExtension */
+	private $extension;
+
+	protected function setUp(): void
+	{
+		$this->broker = $this->createBroker();
+		$this->extension = new FormEventsReflectionExtension();
+	}
+
+	public function testGetProperty(): void
+	{
+		$classReflection = $this->broker->getClass(\Nette\Application\UI\Form::class);
+		self::assertTrue($this->extension->hasProperty($classReflection, 'onSuccess'));
+		$propertyReflection = $this->extension->getProperty($classReflection, 'onSuccess');
+		self::assertSame($classReflection, $propertyReflection->getDeclaringClass());
+		self::assertFalse($propertyReflection->isStatic());
+		self::assertFalse($propertyReflection->isPrivate());
+		self::assertTrue($propertyReflection->isPublic());
+		self::assertSame(
+			sprintf('callable(%s, array<string, mixed>|%s): void', \Nette\Application\UI\Form::class, \Nette\Utils\ArrayHash::class),
+			$propertyReflection->getType()->describe(VerbosityLevel::value())
+		);
+	}
+
+}


### PR DESCRIPTION
Hi,
I added specific callable types for events (right now only for Form, I can continue on others if we agree) - so phpstan can detect more bugs like this
```php
$form->onSuccess[] = function(SubmitButton $button): void {}
```

Is this solution viable or we should try to change nette/forms library?
https://github.com/nette/forms/pull/216