### PR TITLE
Component::GetPresenter returns non-null value in new Nette

### DIFF
--- a/src/Type/Nette/ComponentGetPresenterDynamicReturnTypeExtension.php
+++ b/src/Type/Nette/ComponentGetPresenterDynamicReturnTypeExtension.php
@@ -26,10 +26,17 @@ final class ComponentGetPresenterDynamicReturnTypeExtension implements DynamicMe
 
 	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
 	{
-		$defaultReturnType = ParametersAcceptorSelector::selectSingle(
+		$methodDefinition = ParametersAcceptorSelector::selectSingle(
 			$methodReflection->getVariants()
-		)->getReturnType();
+		);
+		$defaultReturnType = $methodDefinition->getReturnType();
+		$firstParameterExists = count($methodDefinition->getParameters()) > 0;
+
 		if (count($methodCall->args) < 1) {
+			if (!$firstParameterExists) {
+				return TypeCombinator::removeNull($defaultReturnType);
+			}
+
 			return $defaultReturnType;
 		}
 


### PR DESCRIPTION
Call Component::GetPresenter without parameters throws exception in new Nette (non-null return type)

https://github.com/nette/application/blob/6158a56/src/Application/UI/Component.php#L39