### PR TITLE
Identity is now an alias to SimpleIdentity

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -21,6 +21,7 @@ parameters:
 		- Nette\Database\IRow
 		- Nette\Http\SessionSection
 		- Nette\Security\Identity
+		- Nette\Security\SimpleIdentity
 	earlyTerminatingMethodCalls:
 		Nette\Application\UI\Component:
 			- error


### PR DESCRIPTION
Identity has been renamed to SimpleIdentity in nette/security 3.1.0, keeping the old name for backwards compatibility

The commit that has renamed it for reference: https://github.com/nette/security/commit/199ef46076518822cae484114b537d75204e657e

Thanks!