### PR TITLE
UI\ITemplate is an alias to UI\Template

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -17,6 +17,7 @@ parameters:
 		- stubs/Utils/Html.stub
 	universalObjectCratesClasses:
 		- Nette\Application\UI\ITemplate
+		- Nette\Application\UI\Template
 		- Nette\Bridges\ApplicationLatte\Template
 		- Nette\Database\IRow
 		- Nette\Http\SessionSection


### PR DESCRIPTION
Renamed in nette/application 3.1.0, keeping ITemplate for backwards compat.

Here's the commit that has renamed it https://github.com/nette/application/commit/8ffa8fcc937824b19a6027f27ada92b73657ca8b

Thanks!