### PR TITLE
Dynamic return type extension for `getUnsafeValues`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -86,6 +86,11 @@ services:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Nette\FormContainerUnsafeValuesDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Nette\FormContainerValuesDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/src/Type/Nette/FormContainerUnsafeValuesDynamicReturnTypeExtension.php
+++ b/src/Type/Nette/FormContainerUnsafeValuesDynamicReturnTypeExtension.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Nette;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+class FormContainerUnsafeValuesDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return 'Nette\Forms\Container';
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'getUnsafeValues';
+	}
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+	{
+		if (count($methodCall->args) === 0) {
+			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+		}
+
+		$arg = $methodCall->args[0]->value;
+		$scopedType = $scope->getType($arg);
+		if ($scopedType instanceof NullType) {
+			return new ObjectType('Nette\Utils\ArrayHash');
+		}
+
+		if ($scopedType instanceof ConstantStringType && $scopedType->getValue() === 'array') {
+			return new ArrayType(new StringType(), new MixedType());
+		}
+
+		return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+	}
+
+}


### PR DESCRIPTION
Hi,

this adds a dynamic return type extension for `Nette\Forms\Container::getUnsafeValues()` added in nette/forms 3.1.2.

`getUnsafeValues()`, unlike `getValues()`, requires a parameter and doesn't support booleans so I went with a new class instead of multiple `if`s in `FormContainerValuesDynamicReturnTypeExtension`.

Thanks!