### PR TITLE
Add stub for Random::generate()

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -19,6 +19,7 @@ parameters:
 		- stubs/Utils/ArrayHash.stub
 		- stubs/Utils/Html.stub
 		- stubs/Utils/Paginator.stub
+		- stubs/Utils/Random.stub
 	universalObjectCratesClasses:
 		- Nette\Application\UI\ITemplate
 		- Nette\Application\UI\Template

--- a/stubs/Utils/Random.stub
+++ b/stubs/Utils/Random.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace Nette\Utils;
+
+class Random
+{
+	/**
+	 * @param positive-int $length
+	 * @param non-empty-string $charlist
+	 * @return non-empty-string
+	 */
+	public static function generate(int $length = 10, string $charlist = '0-9a-z'): string
+	{
+		// nothing
+	}
+}


### PR DESCRIPTION
Encountered an issue with PHPStan not being aware that `Random::generate()` never returns an empty string.