### PR TITLE
Fixed component model return type extensions for cases where createComponent method is not present

### DIFF
--- a/src/Type/Nette/ComponentModelArrayAccessDynamicReturnTypeExtension.php
+++ b/src/Type/Nette/ComponentModelArrayAccessDynamicReturnTypeExtension.php
@@ -7,7 +7,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
@@ -36,15 +35,15 @@ class ComponentModelArrayAccessDynamicReturnTypeExtension implements DynamicMeth
 	): Type
 	{
 		$calledOnType = $scope->getType($methodCall->var);
-		$mixedType = new MixedType();
+		$defaultType = ParametersAcceptorSelector::selectSingle($calledOnType->getMethod('createComponent', $scope)->getVariants())->getReturnType();
 		$args = $methodCall->getArgs();
 		if (count($args) !== 1) {
-			return $mixedType;
+			return $defaultType;
 		}
 
 		$argType = $scope->getType($args[0]->value);
 		if (count($argType->getConstantStrings()) === 0) {
-			return $mixedType;
+			return $defaultType;
 		}
 
 		$types = [];
@@ -53,7 +52,7 @@ class ComponentModelArrayAccessDynamicReturnTypeExtension implements DynamicMeth
 
 			$methodName = sprintf('createComponent%s', ucfirst($componentName));
 			if (!$calledOnType->hasMethod($methodName)->yes()) {
-				return $mixedType;
+				return $defaultType;
 			}
 
 			$method = $calledOnType->getMethod($methodName, $scope);

--- a/src/Type/Nette/ComponentModelDynamicReturnTypeExtension.php
+++ b/src/Type/Nette/ComponentModelDynamicReturnTypeExtension.php
@@ -7,7 +7,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
@@ -36,15 +35,15 @@ class ComponentModelDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 	): Type
 	{
 		$calledOnType = $scope->getType($methodCall->var);
-		$mixedType = new MixedType();
+		$defaultType = ParametersAcceptorSelector::selectSingle($calledOnType->getMethod('createComponent', $scope)->getVariants())->getReturnType();
 		$args = $methodCall->getArgs();
 		if (count($args) !== 1) {
-			return $mixedType;
+			return $defaultType;
 		}
 
 		$argType = $scope->getType($args[0]->value);
 		if (count($argType->getConstantStrings()) === 0) {
-			return $mixedType;
+			return $defaultType;
 		}
 
 		$types = [];
@@ -53,7 +52,7 @@ class ComponentModelDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 
 			$methodName = sprintf('createComponent%s', ucfirst($componentName));
 			if (!$calledOnType->hasMethod($methodName)->yes()) {
-				return $mixedType;
+				return $defaultType;
 			}
 
 			$method = $calledOnType->getMethod($methodName, $scope);

--- a/tests/Type/Nette/ComponentModelArrayAccessDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Nette/ComponentModelArrayAccessDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Nette;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class ComponentModelArrayAccessDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+
+	/**
+	 * @return iterable<string, mixed[]>
+	 */
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/componentModelArrayAccess.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/phpstan.neon',
+		];
+	}
+
+}

--- a/tests/Type/Nette/ComponentModelDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Nette/ComponentModelDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Nette;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class ComponentModelDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+
+	/**
+	 * @return iterable<string, mixed[]>
+	 */
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/componentModel.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/phpstan.neon',
+		];
+	}
+
+}

--- a/tests/Type/Nette/data/componentModel.php
+++ b/tests/Type/Nette/data/componentModel.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace PHPStan\Type\Nette\Data\ComponentModel;
+
+use Nette\Application\UI\Control;
+use function PHPStan\Testing\assertType;
+
+class SomeControl extends Control {
+
+	public function createComponentSome(): self {
+		return new SomeControl();
+	}
+
+}
+
+class AnotherControl extends Control {
+
+	public function createComponentAnother(): AnotherControl {
+		return new AnotherControl();
+	}
+
+	public function createComponentSome(): SomeControl {
+		return new SomeControl();
+	}
+
+}
+
+class OverrideCreateControl extends Control {
+
+	public function createComponent(string $name): AnotherControl {
+		return new AnotherControl();
+	}
+
+}
+
+$someControl = new SomeControl();
+assertType('PHPStan\Type\Nette\Data\ComponentModel\SomeControl', $someControl->getComponent('some'));
+assertType('Nette\ComponentModel\IComponent|null', $someControl->getComponent('unknown'));
+
+$anotherControl = new AnotherControl();
+assertType('PHPStan\Type\Nette\Data\ComponentModel\AnotherControl', $anotherControl->getComponent('another'));
+assertType('PHPStan\Type\Nette\Data\ComponentModel\SomeControl', $anotherControl->getComponent('some'));
+assertType('Nette\ComponentModel\IComponent|null', $anotherControl->getComponent('unknown'));
+
+$overrideCreateControl = new OverrideCreateControl();
+assertType('PHPStan\Type\Nette\Data\ComponentModel\AnotherControl', $overrideCreateControl->getComponent('some'));
+assertType('PHPStan\Type\Nette\Data\ComponentModel\AnotherControl', $overrideCreateControl->getComponent('unknown'));

--- a/tests/Type/Nette/data/componentModelArrayAccess.php
+++ b/tests/Type/Nette/data/componentModelArrayAccess.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace PHPStan\Type\Nette\Data\ComponentModelArrayAccess;
+
+use Nette\Application\UI\Control;
+use function PHPStan\Testing\assertType;
+
+class SomeControl extends Control {
+
+	public function createComponentSome(): self {
+		return new SomeControl();
+	}
+
+}
+
+class AnotherControl extends Control {
+
+	public function createComponentAnother(): AnotherControl {
+		return new AnotherControl();
+	}
+
+	public function createComponentSome(): SomeControl {
+		return new SomeControl();
+	}
+
+}
+
+class OverrideCreateControl extends Control {
+
+	public function createComponent(string $name): AnotherControl {
+		return new AnotherControl();
+	}
+
+}
+
+$someControl = new SomeControl();
+assertType('PHPStan\Type\Nette\Data\ComponentModelArrayAccess\SomeControl', $someControl['some']);
+assertType('Nette\ComponentModel\IComponent|null', $someControl['unknown']);
+
+$anotherControl = new AnotherControl();
+assertType('PHPStan\Type\Nette\Data\ComponentModelArrayAccess\AnotherControl', $anotherControl['another']);
+assertType('PHPStan\Type\Nette\Data\ComponentModelArrayAccess\SomeControl', $anotherControl['some']);
+assertType('Nette\ComponentModel\IComponent|null', $anotherControl['unknown']);
+
+$overrideCreateControl = new OverrideCreateControl();
+assertType('PHPStan\Type\Nette\Data\ComponentModelArrayAccess\AnotherControl', $overrideCreateControl['some']);
+assertType('PHPStan\Type\Nette\Data\ComponentModelArrayAccess\AnotherControl', $overrideCreateControl['unknown']);

--- a/tests/Type/Nette/phpstan.neon
+++ b/tests/Type/Nette/phpstan.neon
@@ -1,0 +1,3 @@
+includes:
+	- ../../../extension.neon
+	- ../../../rules.neon


### PR DESCRIPTION
When used with combination with `Container` that overwrites `getComponent` (like `Multiplier`) return type was forced to mixed instead of keeping return type of `getComponent` in case `createComponent*` method was not present