### PR TITLE
Html: proper types for setHtml and addHtml methods – same as insert() method

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -18,6 +18,7 @@ parameters:
 		- stubs/Forms/Container.stub
 		- stubs/Forms/Form.stub
 		- stubs/Forms/Rules.stub
+		- stubs/HtmlStringable.stub
 		- stubs/Http/SessionSection.stub
 		- stubs/Routing/Router.stub
 		- stubs/Utils/ArrayHash.stub

--- a/stubs/HtmlStringable.stub
+++ b/stubs/HtmlStringable.stub
@@ -2,7 +2,9 @@
 
 namespace Nette;
 
-interface HtmlStringable extends \Stringable
+interface HtmlStringable
 {
+
+	public function __toString(): string;
 
 }

--- a/stubs/HtmlStringable.stub
+++ b/stubs/HtmlStringable.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace Nette;
+
+interface HtmlStringable extends \Stringable
+{
+
+}

--- a/stubs/Utils/Html.stub
+++ b/stubs/Utils/Html.stub
@@ -2,6 +2,8 @@
 
 namespace Nette\Utils;
 
+use Nette\HtmlStringable;
+
 /**
  * @implements \IteratorAggregate<int, self|string>
  * @implements \ArrayAccess<int, self|string>
@@ -13,6 +15,22 @@ class Html implements \ArrayAccess, \IteratorAggregate
 	 * @return \ArrayIterator<int, self|string>
 	 */
 	public function getIterator(): \ArrayIterator
+	{
+		// nothing
+	}
+
+	/**
+	 * @param string|HtmlStringable $html
+	 */
+	public function setHtml(mixed $html): static
+	{
+		// nothing
+	}
+
+	/**
+	 * @param string|HtmlStringable $child
+	 */
+	final public function addHtml(mixed $child): static
 	{
 		// nothing
 	}

--- a/stubs/Utils/Html.stub
+++ b/stubs/Utils/Html.stub
@@ -20,14 +20,6 @@ class Html implements \ArrayAccess, \IteratorAggregate
 	}
 
 	/**
-	 * @param string|HtmlStringable $html
-	 */
-	public function setHtml(mixed $html): static
-	{
-		// nothing
-	}
-
-	/**
 	 * @param string|HtmlStringable $child
 	 */
 	final public function addHtml(mixed $child): static


### PR DESCRIPTION
fixes `Nette\Utils\Html::insert(): Argument #2 ($child) must be of type Nette\HtmlStringable|string, XY given`