### PR TITLE
Property with #[Inject] attribute is initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This extension provides following features:
 * Magic [Nette\Object and Nette\SmartObject](https://doc.nette.org/en/2.4/php-language-enhancements) properties
 * Event listeners through the `on*` properties
 * Defines early terminating method calls for Presenter methods to prevent `Undefined variable` errors
+* `@inject` annotation and `#[Nette\DI\Attributes\Inject]` attribute initialize properties
 
 It also contains these framework-specific rules (can be enabled separately):
 

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 	},
 	"require-dev": {
 		"nette/application": "^3.0",
+		"nette/di": "^2.3.0 || ^3.0.0",
 		"nette/forms": "^3.0",
 		"nette/utils": "^2.3.0 || ^3.0.0",
 		"nikic/php-parser": "^4.13.2",

--- a/src/Rule/Nette/PresenterInjectedPropertiesExtension.php
+++ b/src/Rule/Nette/PresenterInjectedPropertiesExtension.php
@@ -2,12 +2,22 @@
 
 namespace PHPStan\Rule\Nette;
 
+use Nette\DI\Attributes\Inject;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Rules\Properties\ReadWritePropertiesExtension;
 use function strpos;
 
 class PresenterInjectedPropertiesExtension implements ReadWritePropertiesExtension
 {
+
+	/** @var PhpVersion */
+	private $phpVersion;
+
+	public function __construct(PhpVersion $phpVersion)
+	{
+		$this->phpVersion = $phpVersion;
+	}
 
 	public function isAlwaysRead(PropertyReflection $property, string $propertyName): bool
 	{
@@ -21,8 +31,20 @@ class PresenterInjectedPropertiesExtension implements ReadWritePropertiesExtensi
 
 	public function isInitialized(PropertyReflection $property, string $propertyName): bool
 	{
-		return $property->isPublic() &&
-			strpos($property->getDocComment() ?? '', '@inject') !== false;
+		if (!$property->isPublic()) {
+			return false;
+		}
+
+		if (strpos($property->getDocComment() ?? '', '@inject') !== false) {
+			return true;
+		}
+
+		$nativeProperty = $property->getDeclaringClass()->getNativeProperty($propertyName)->getNativeReflection();
+		if ($this->phpVersion->getVersionId() >= 80000 && $nativeProperty->getAttributes(Inject::class) !== []) {
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/tests/Rule/Nette/PresenterInjectedPropertiesExtensionTest.php
+++ b/tests/Rule/Nette/PresenterInjectedPropertiesExtensionTest.php
@@ -14,9 +14,15 @@ class PresenterInjectedPropertiesExtensionTest extends LevelsTestCase
 			self::markTestSkipped('Only for PHP 7.4+');
 		}
 
-		return [
+		$topics = [
 			['presenterInject'],
 		];
+
+		if (PHP_VERSION_ID >= 80000) {
+			$topics[] = ['presenterInjectAttribute'];
+		}
+
+		return $topics;
 	}
 
 	public function getDataPath(): string

--- a/tests/Rule/Nette/data/presenterInjectAttribute.php
+++ b/tests/Rule/Nette/data/presenterInjectAttribute.php
@@ -1,0 +1,14 @@
+<?php
+
+use Nette\DI\Attributes\Inject;
+
+class Service
+{
+
+}
+
+class InjectAttributePresenter
+{
+	#[Inject]
+	public Service $service;
+}


### PR DESCRIPTION
Adding support for inject attributes https://doc.nette.org/en/best-practices/inject-method-attribute#toc-inject-attributes

I am a bit stuck on why the test is failing - same code with native ReflectionProperty works just fine https://3v4l.org/3HF1T

Also my usual primitive debugging methods don't work as usual - var_dump() in tested code makes it stuck indefinitely and e.g. `\PHPUnit\Framework\assertFalse(true)`  in tested code does not make the test fail

For the phpstan failure - should I just add it to ignored? Class does not have to exist in this case.