### PR TITLE
Update ComponentModel\Container stub for component-model 3.1.0 and 4.0.0

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -11,7 +11,6 @@ parameters:
 		- stubs/Application/UI/Presenter.stub
 		- stubs/Caching/Cache.stub
 		- stubs/ComponentModel/Component.stub
-		- stubs/ComponentModel/Container.stub
 		- stubs/ComponentModel/IComponent.stub
 		- stubs/ComponentModel/IContainer.stub
 		- stubs/Database/ResultSet.stub
@@ -127,3 +126,8 @@ services:
 		class: PHPStan\Type\Nette\StringsReplaceCallbackClosureTypeExtension
 		tags:
 			- phpstan.staticMethodParameterClosureTypeExtension
+
+	-
+		class: PHPStan\Stubs\Nette\StubFilesExtensionLoader
+		tags:
+			- phpstan.stubFilesExtension

--- a/extension.neon
+++ b/extension.neon
@@ -10,7 +10,6 @@ parameters:
 		- stubs/Application/UI/Presenter.stub
 		- stubs/Caching/Cache.stub
 		- stubs/ComponentModel/Component.stub
-		- stubs/ComponentModel/Container.stub
 		- stubs/ComponentModel/IComponent.stub
 		- stubs/ComponentModel/IContainer.stub
 		- stubs/Database/ResultSet.stub
@@ -147,3 +146,8 @@ services:
 		class: PHPStan\Type\Nette\StringsLengthDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicStaticMethodReturnTypeExtension
+
+	-
+		class: PHPStan\Stubs\Nette\StubFilesExtensionLoader
+		tags:
+			- phpstan.stubFilesExtension

--- a/src/Stubs/Nette/StubFilesExtensionLoader.php
+++ b/src/Stubs/Nette/StubFilesExtensionLoader.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Stubs\Nette;
+
+use Composer\InstalledVersions;
+use OutOfBoundsException;
+use PHPStan\PhpDoc\StubFilesExtension;
+use function class_exists;
+use function dirname;
+use function version_compare;
+
+class StubFilesExtensionLoader implements StubFilesExtension
+{
+
+	public function getFiles(): array
+	{
+		$stubsDir = dirname(dirname(dirname(__DIR__))) . '/stubs';
+		$path = $stubsDir;
+
+		$files = [];
+
+		$componentModelVersion = self::getInstalledVersion('nette/component-model');
+		if ($componentModelVersion !== null && version_compare($componentModelVersion, '3.1.0', '>=')) {
+			$files[] = $path . '/ComponentModel/Container_3_1.stub';
+		} else {
+			$files[] = $path . '/ComponentModel/Container.stub';
+		}
+
+		return $files;
+	}
+
+	private static function getInstalledVersion(string $package): ?string
+	{
+		if (!class_exists(InstalledVersions::class)) {
+			return null;
+		}
+
+		try {
+			$installedVersion = InstalledVersions::getVersion($package);
+		} catch (OutOfBoundsException $e) {
+			return null;
+		}
+
+		return $installedVersion;
+	}
+
+}

--- a/src/Stubs/Nette/StubFilesExtensionLoader.php
+++ b/src/Stubs/Nette/StubFilesExtensionLoader.php
@@ -27,7 +27,7 @@ class StubFilesExtensionLoader implements StubFilesExtension
 
 		if (version_compare($componentModelVersion, '3.1.0', '<')) {
 			$files[] = $path . '/ComponentModel/Container.stub';
-		} else {
+		} elseif (version_compare($componentModelVersion, '4.0.0', '<')) {
 			$files[] = $path . '/ComponentModel/Container_3_1.stub';
 		}
 

--- a/src/Stubs/Nette/StubFilesExtensionLoader.php
+++ b/src/Stubs/Nette/StubFilesExtensionLoader.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Stubs\Nette;
+
+use Composer\InstalledVersions;
+use OutOfBoundsException;
+use PHPStan\PhpDoc\StubFilesExtension;
+use function class_exists;
+use function dirname;
+use function version_compare;
+
+class StubFilesExtensionLoader implements StubFilesExtension
+{
+
+	public function getFiles(): array
+	{
+		$stubsDir = dirname(dirname(dirname(__DIR__))) . '/stubs';
+		$path = $stubsDir;
+
+		$files = [];
+
+		$componentModelVersion = self::getInstalledVersion('nette/component-model');
+
+		if ($componentModelVersion === null) {
+			return [];
+		}
+
+		if (version_compare($componentModelVersion, '3.1.0', '<')) {
+			$files[] = $path . '/ComponentModel/Container.stub';
+		} else {
+			$files[] = $path . '/ComponentModel/Container_3_1.stub';
+		}
+
+		return $files;
+	}
+
+	private static function getInstalledVersion(string $package): ?string
+	{
+		if (!class_exists(InstalledVersions::class)) {
+			return null;
+		}
+
+		try {
+			$installedVersion = InstalledVersions::getVersion($package);
+		} catch (OutOfBoundsException $e) {
+			return null;
+		}
+
+		return $installedVersion;
+	}
+
+}

--- a/stubs/ComponentModel/Container.stub
+++ b/stubs/ComponentModel/Container.stub
@@ -10,7 +10,7 @@ class Container extends Component implements IContainer
 	 * @phpstan-param null|class-string<T> $filterType
 	 * @phpstan-return ($filterType is null ? \Iterator<int|string, \Nette\ComponentModel\IComponent> : \Iterator<int|string, T>)
 	 */
-	public function getComponents(bool $deep = false, string $filterType = null): \Iterator
+	public function getComponents(bool $deep = false, ?string $filterType = null): \Iterator
 	{
 		// nothing
 	}

--- a/stubs/ComponentModel/Container_3_1.stub
+++ b/stubs/ComponentModel/Container_3_1.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace Nette\ComponentModel;
+
+class Container extends Component implements IContainer
+{
+
+	/**
+	 * @template T of \Nette\ComponentModel\IComponent
+	 * @phpstan-param null|class-string<T> $filterType
+	 * @phpstan-return (
+	 * 	$deep is false
+	 * 	? ($filterType is null ? array<int|string, \Nette\ComponentModel\IComponent> : array<int|string, T>)
+	 * 	: ($filterType is null ? \Iterator<int|string, \Nette\ComponentModel\IComponent> : \Iterator<int|string, T>)
+	 * )
+	 */
+	public function getComponents(bool $deep = false, ?string $filterType = null): iterable
+	{
+		// nothing
+	}
+}

--- a/tests/Type/Nette/ComponentModelContainerDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Nette/ComponentModelContainerDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Nette;
+
+use Composer\InstalledVersions;
+use OutOfBoundsException;
+use PHPStan\Testing\TypeInferenceTestCase;
+use function class_exists;
+use function version_compare;
+
+class ComponentModelContainerDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+
+	/**
+	 * @return iterable<string, mixed[]>
+	 */
+	public function dataFileAsserts(): iterable
+	{
+		$componentModelVersion = self::getInstalledVersion('nette/component-model');
+
+		$suffix = $componentModelVersion !== null && version_compare($componentModelVersion, '3.1.0', '>=') ? '31' : '';
+
+		yield from self::gatherAssertTypes(__DIR__ . '/data/componentModelContainer' . $suffix . '.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/phpstan.neon',
+		];
+	}
+
+	private static function getInstalledVersion(string $package): ?string
+	{
+		if (!class_exists(InstalledVersions::class)) {
+			return null;
+		}
+
+		try {
+			$installedVersion = InstalledVersions::getVersion($package);
+		} catch (OutOfBoundsException $e) {
+			return null;
+		}
+
+		return $installedVersion;
+	}
+
+}

--- a/tests/Type/Nette/ComponentModelContainerDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Nette/ComponentModelContainerDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Nette;
+
+use Composer\InstalledVersions;
+use OutOfBoundsException;
+use PHPStan\Testing\TypeInferenceTestCase;
+use function class_exists;
+use function version_compare;
+
+class ComponentModelContainerDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+
+	/**
+	 * @return iterable<string, mixed[]>
+	 */
+	public function dataFileAsserts(): iterable
+	{
+		yield from self::gatherAssertTypes(__DIR__ . '/data/componentModelContainer' . self::getVersionSuffix() . '.php');
+	}
+
+	private static function getVersionSuffix(): string
+	{
+		$componentModelVersion = self::getInstalledVersion('nette/component-model');
+
+		if ($componentModelVersion === null) {
+			return '';
+		}
+
+		if (version_compare($componentModelVersion, '3.1.0', '>=')) {
+			return '31';
+		}
+
+		return '';
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/phpstan.neon',
+		];
+	}
+
+	private static function getInstalledVersion(string $package): ?string
+	{
+		if (!class_exists(InstalledVersions::class)) {
+			return null;
+		}
+
+		try {
+			$installedVersion = InstalledVersions::getVersion($package);
+		} catch (OutOfBoundsException $e) {
+			return null;
+		}
+
+		return $installedVersion;
+	}
+
+}

--- a/tests/Type/Nette/ComponentModelContainerDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Nette/ComponentModelContainerDynamicReturnTypeExtensionTest.php
@@ -27,6 +27,10 @@ class ComponentModelContainerDynamicReturnTypeExtensionTest extends TypeInferenc
 			return '';
 		}
 
+		if (version_compare($componentModelVersion, '4.0.0', '>=')) {
+			return '40';
+		}
+
 		if (version_compare($componentModelVersion, '3.1.0', '>=')) {
 			return '31';
 		}

--- a/tests/Type/Nette/data/componentModelContainer.php
+++ b/tests/Type/Nette/data/componentModelContainer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PHPStan\Type\Nette\Data\ComponentModel;
+
+use Nette\Application\UI\Form;
+use Nette\Forms\Container;
+use function PHPStan\Testing\assertType;
+
+class SomeForm extends Form {
+}
+
+$someForm = new SomeForm();
+
+assertType('Iterator<int|string, Nette\ComponentModel\IComponent>', $someForm->getComponents(false));
+assertType('Iterator<int|string, Nette\Forms\Container>', $someForm->getComponents(false, Container::class));
+assertType('Iterator<int|string, Nette\ComponentModel\IComponent>', $someForm->getComponents(true));
+assertType('Iterator<int|string, Nette\Forms\Container>', $someForm->getComponents(true, Container::class));

--- a/tests/Type/Nette/data/componentModelContainer31.php
+++ b/tests/Type/Nette/data/componentModelContainer31.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PHPStan\Type\Nette\Data\ComponentModel;
+
+use Nette\Application\UI\Form;
+use Nette\Forms\Container;
+use function PHPStan\Testing\assertType;
+
+class SomeForm extends Form {
+}
+
+$someForm = new SomeForm();
+
+assertType('array<int|string, Nette\ComponentModel\IComponent>', $someForm->getComponents(false));
+assertType('array<int|string, Nette\Forms\Container>', $someForm->getComponents(false, Container::class));
+assertType('Iterator<int|string, Nette\ComponentModel\IComponent>', $someForm->getComponents(true));
+assertType('Iterator<int|string, Nette\Forms\Container>', $someForm->getComponents(true, Container::class));

--- a/tests/Type/Nette/data/componentModelContainer31.php
+++ b/tests/Type/Nette/data/componentModelContainer31.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PHPStan\Type\Nette\Data\ComponentModel;
+
+use Nette\Application\UI\Form;
+use Nette\Forms\Container;
+use function PHPStan\Testing\assertType;
+
+class SomeForm31 extends Form {
+}
+
+$someForm = new SomeForm31();
+
+assertType('array<int|string, Nette\ComponentModel\IComponent>', $someForm->getComponents(false));
+assertType('array<int|string, Nette\Forms\Container>', $someForm->getComponents(false, Container::class));
+assertType('Iterator<int|string, Nette\ComponentModel\IComponent>', $someForm->getComponents(true));
+assertType('Iterator<int|string, Nette\Forms\Container>', $someForm->getComponents(true, Container::class));

--- a/tests/Type/Nette/data/componentModelContainer40.php
+++ b/tests/Type/Nette/data/componentModelContainer40.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHPStan\Type\Nette\Data\ComponentModel;
+
+use Nette\Application\UI\Form;
+use function PHPStan\Testing\assertType;
+
+class SomeForm40 extends Form {
+}
+
+$someForm = new SomeForm40();
+
+assertType('array<Nette\ComponentModel\IComponent>', $someForm->getComponents());


### PR DESCRIPTION
component-model 3.1.0 changes the return type to array when `$deep` argument is `false` (default):
https://github.com/nette/component-model/commit/7f613eed7f5e57b6bde2d0be1bfdbb7e161620b3

It also deprecates the arguments but we cannot add deprecated annotation to those.
https://github.com/nette/component-model/commit/4e0946a788b4ac42ea903b761c693ec7dd083a69

Furthermore, version 4.0.0 changes the return type of `Container::getComponents` to a properly typed array and removes support for extra arguments:
https://github.com/nette/component-model/commit/c40aa8ed45324438100a4d931ed1fb8dc16b4f34

Let’s drop the stub on that version.