### PR TITLE
StringsMatchDynamicReturnTypeExtensionTest does not need bleeding edge

### DIFF
--- a/tests/Type/Nette/StringsMatchDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Nette/StringsMatchDynamicReturnTypeExtensionTest.php
@@ -31,7 +31,6 @@ class StringsMatchDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [
-			'phar://' . __DIR__ . '/../../../vendor/phpstan/phpstan/phpstan.phar/conf/bleedingEdge.neon',
 			__DIR__ . '/phpstan.neon',
 		];
 	}


### PR DESCRIPTION
The ArrayShapeMatcher does not depend on feature flags