### PR TITLE
Skip StringsMatchDynamicReturnTypeExtensionTest on PHP 7.2/7.3

### DIFF
--- a/tests/Type/Nette/ComponentModelArrayAccessDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Nette/ComponentModelArrayAccessDynamicReturnTypeExtensionTest.php
@@ -12,7 +12,7 @@ class ComponentModelArrayAccessDynamicReturnTypeExtensionTest extends TypeInfere
 	 */
 	public function dataFileAsserts(): iterable
 	{
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/componentModelArrayAccess.php');
+		yield from self::gatherAssertTypes(__DIR__ . '/data/componentModelArrayAccess.php');
 	}
 
 	/**

--- a/tests/Type/Nette/MultiplierTest.php
+++ b/tests/Type/Nette/MultiplierTest.php
@@ -10,7 +10,7 @@ class MultiplierTest extends TypeInferenceTestCase
 	/** @return iterable<mixed> */
 	public function dataFileAsserts(): iterable
 	{
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/multiplier.php');
+		yield from self::gatherAssertTypes(__DIR__ . '/data/multiplier.php');
 	}
 
 	/**

--- a/tests/Type/Nette/StringsMatchDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Nette/StringsMatchDynamicReturnTypeExtensionTest.php
@@ -12,7 +12,7 @@ class StringsMatchDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
 	 */
 	public function dataFileAsserts(): iterable
 	{
-		if (PHP_VERSION_ID < 70400) {
+		if (PHP_VERSION_ID >= 70400) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/strings-match.php');
 		}
 	}

--- a/tests/Type/Nette/StringsMatchDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Nette/StringsMatchDynamicReturnTypeExtensionTest.php
@@ -17,7 +17,7 @@ class StringsMatchDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
 			return;
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/strings-match.php');
+		yield from self::gatherAssertTypes(__DIR__ . '/data/strings-match.php');
 	}
 
 	/**

--- a/tests/Type/Nette/StringsMatchDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Nette/StringsMatchDynamicReturnTypeExtensionTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type\Nette;
 
 use PHPStan\Testing\TypeInferenceTestCase;
+use const PHP_VERSION_ID;
 
 class StringsMatchDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
 {
@@ -12,9 +13,11 @@ class StringsMatchDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
 	 */
 	public function dataFileAsserts(): iterable
 	{
-		if (PHP_VERSION_ID >= 70400) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/strings-match.php');
+		if (PHP_VERSION_ID < 70400) {
+			return;
 		}
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/strings-match.php');
 	}
 
 	/**

--- a/tests/Type/Nette/StringsMatchDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Nette/StringsMatchDynamicReturnTypeExtensionTest.php
@@ -12,7 +12,9 @@ class StringsMatchDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
 	 */
 	public function dataFileAsserts(): iterable
 	{
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/strings-match.php');
+		if (PHP_VERSION_ID < 70400) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/strings-match.php');
+		}
 	}
 
 	/**


### PR DESCRIPTION
ArrayShapeMatcher does not work for these old php versions

should fix phpstan-src CI errors

<img width="859" alt="grafik" src="https://github.com/phpstan/phpstan-nette/assets/120441/aa5e919b-69f0-4522-acd7-cf8f0f024b0a">
