### PR TITLE
Added missing @template tag to Selection stub

### DIFF
--- a/stubs/Database/Table/Selection.stub
+++ b/stubs/Database/Table/Selection.stub
@@ -3,25 +3,26 @@
 namespace Nette\Database\Table;
 
 /**
- * @phpstan-implements \Iterator<string, ActiveRow>
- * @phpstan-implements \ArrayAccess<string, \Nette\Database\IRow>
+ * @template T of ActiveRow
+ * @phpstan-implements \Iterator<string, T>
+ * @phpstan-implements \ArrayAccess<string, T>
  */
 class Selection implements \Iterator, \ArrayAccess
 {
     /**
      * @phpstan-param positive-int|0|null $limit
      * @phpstan-param positive-int|0|null $offset
-     * @return static
+     * @return static<T>
      */
     public function limit(?int $limit, int $offset = null)
     {
     }
-    
+
     /**
      * @phpstan-param positive-int|0 $page
      * @phpstan-param positive-int|0 $itemsPerPage
      * @param int $numOfPages [optional]
-     * @return static
+     * @return static<T>
      */
     public function page(int $page, int $itemsPerPage, &$numOfPages = null)
     {
@@ -30,12 +31,12 @@ class Selection implements \Iterator, \ArrayAccess
     /**
      * @param string|array<string|int,mixed> $condition
      * @param mixed $params
-     * @return static
+     * @return static<T>
      */
     public function where($condition, ...$params)
     {
     }
- 
+
     /**
      * @param string $column
      * @return positive-int|0


### PR DESCRIPTION
Hi, the nette/database version 3.2.4 added a `@template` tag to the Selection class. 

I have updated the Selection stub to reflect the nette/database changes.