### PR TITLE
Fix PHP 8.4 deprecation warnings for implicitly nullable parameters

### DIFF
--- a/stubs/ComponentModel/Container.stub
+++ b/stubs/ComponentModel/Container.stub
@@ -10,7 +10,7 @@ class Container extends Component implements IContainer
 	 * @phpstan-param null|class-string<T> $filterType
 	 * @phpstan-return ($filterType is null ? \Iterator<int|string, \Nette\ComponentModel\IComponent> : \Iterator<int|string, T>)
 	 */
-	public function getComponents(bool $deep = false, string $filterType = null): \Iterator
+	public function getComponents(bool $deep = false, ?string $filterType = null): \Iterator
 	{
 		// nothing
 	}

--- a/stubs/Database/Table/Selection.stub
+++ b/stubs/Database/Table/Selection.stub
@@ -14,7 +14,7 @@ class Selection implements \Iterator, \ArrayAccess
      * @phpstan-param positive-int|0|null $offset
      * @return static<T>
      */
-    public function limit(?int $limit, int $offset = null)
+    public function limit(?int $limit, ?int $offset = null)
     {
     }
 


### PR DESCRIPTION
## Summary
- Fixed PHP 8.4 deprecation warnings in `Container.stub` and `Selection.stub`
- Made implicitly nullable parameters explicitly nullable:
  - `Container::getComponents()`: `string $filterType = null` → `?string $filterType = null`
  - `Selection::limit()`: `int $offset = null` → `?int $offset = null`

## Test plan
- [x] All tests pass (PHPUnit: 60/60 tests, 9 skipped)
- [x] PHPStan analysis passes with no errors
- [x] Code style checks pass
- [x] Lint checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)