### PR TITLE
fix Form getValues() invalid type

### DIFF
--- a/src/Type/Nette/FormContainerValuesDynamicReturnTypeExtension.php
+++ b/src/Type/Nette/FormContainerValuesDynamicReturnTypeExtension.php
@@ -26,22 +26,36 @@ final class FormContainerValuesDynamicReturnTypeExtension implements DynamicMeth
 		return $methodReflection->getName() === 'getValues';
 	}
 
-	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
 	{
-		if (count($methodCall->getArgs()) === 0) {
+		$args = $methodCall->getArgs();
+
+		if (count($args) === 0) {
 			return new ObjectType('Nette\Utils\ArrayHash');
 		}
 
-		$arg = $methodCall->getArgs()[0]->value;
+		$arg = $args[0]->value;
 		$scopedType = $scope->getType($arg);
-		if ($scopedType->isTrue()->yes()) {
+
+		$constantStrings = $scopedType->getConstantStrings();
+
+		if (count($constantStrings) === 0) {
+			return new ObjectType('Nette\Utils\ArrayHash');
+		}
+
+		$constantString = $constantStrings[0];
+
+		$value = $constantString->getValue();
+
+		if ($scopedType->isClassString()->yes()) {
+			return $scopedType->getClassStringObjectType();
+		}
+
+		if ($value === 'array') {
 			return new ArrayType(new StringType(), new MixedType());
 		}
-		if ($scopedType->isFalse()->yes()) {
-			return new ObjectType('Nette\Utils\ArrayHash');
-		}
 
-		return null;
+		return new ObjectType('Nette\Utils\ArrayHash');
 	}
 
 }

--- a/tests/Type/Nette/FormContainerValuesDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Nette/FormContainerValuesDynamicReturnTypeExtensionTest.php
@@ -2,106 +2,37 @@
 
 namespace PHPStan\Type\Nette;
 
-use Nette\Utils\ArrayHash;
-use PhpParser\Node\Arg;
-use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\MethodCall;
-use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\FunctionVariant;
-use PHPStan\Reflection\MethodReflection;
-use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantBooleanType;
-use PHPStan\Type\Generic\TemplateTypeMap;
-use PHPStan\Type\IterableType;
-use PHPStan\Type\MixedType;
-use PHPStan\Type\ObjectType;
-use PHPStan\Type\UnionType;
-use PHPStan\Type\VerbosityLevel;
-use PHPUnit\Framework\TestCase;
+use PHPStan\Testing\TypeInferenceTestCase;
 
-final class FormContainerValuesDynamicReturnTypeExtensionTest extends TestCase
+final class FormContainerValuesDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
 {
 
-	private FormContainerValuesDynamicReturnTypeExtension $extension;
-
-	protected function setUp(): void
+	/**
+	 * @return iterable<string, mixed[]>
+	 */
+	public static function dataFileAsserts(): iterable
 	{
-		$this->extension = new FormContainerValuesDynamicReturnTypeExtension();
+		yield from self::gatherAssertTypes(__DIR__ . '/data/FormContainerModel.php');
 	}
 
-	public function testParameterAsArray(): void
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
 	{
-		$methodReflection = $this->createMock(MethodReflection::class);
-		$methodReflection
-			->method('getVariants')
-			->willReturn([new FunctionVariant(
-				TemplateTypeMap::createEmpty(),
-				TemplateTypeMap::createEmpty(),
-				[],
-				true,
-				new UnionType([new ArrayType(new MixedType(), new MixedType()), new IterableType(new MixedType(), new ObjectType(ArrayHash::class))]),
-			)]);
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
 
-		$scope = $this->createMock(Scope::class);
-		$scope->method('getType')->willReturn(new ConstantBooleanType(true));
-
-		$methodCall = $this->createMock(MethodCall::class);
-		$arg = $this->createMock(Arg::class);
-		$value = $this->createMock(Expr::class);
-		$arg->value = $value;
-		$methodCall->args = [
-			0 => $arg,
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/phpstan.neon',
 		];
-		$methodCall->method('getArgs')->willReturn($methodCall->args);
-
-		$resultType = $this->extension->getTypeFromMethodCall($methodReflection, $methodCall, $scope);
-
-		self::assertInstanceOf(ArrayType::class, $resultType);
-	}
-
-	public function testParameterAsArrayHash(): void
-	{
-		$methodReflection = $this->createMock(MethodReflection::class);
-		$methodReflection
-			->method('getVariants')
-			->willReturn([new FunctionVariant(TemplateTypeMap::createEmpty(), TemplateTypeMap::createEmpty(), [], true, new UnionType([new ArrayType(new MixedType(), new MixedType()), new IterableType(new MixedType(), new ObjectType(ArrayHash::class))]))]);
-
-		$scope = $this->createMock(Scope::class);
-		$scope->method('getType')->willReturn(new ConstantBooleanType(false));
-
-		$methodCall = $this->createMock(MethodCall::class);
-		$arg = $this->createMock(Arg::class);
-		$value = $this->createMock(Expr::class);
-		$arg->value = $value;
-		$methodCall->args = [
-			0 => $arg,
-		];
-		$methodCall->method('getArgs')->willReturn($methodCall->args);
-
-		$resultType = $this->extension->getTypeFromMethodCall($methodReflection, $methodCall, $scope);
-
-		self::assertInstanceOf(ObjectType::class, $resultType);
-		self::assertSame(ArrayHash::class, $resultType->describe(VerbosityLevel::value()));
-	}
-
-	public function testDefaultParameterIsArrayHash(): void
-	{
-		$methodReflection = $this->createMock(MethodReflection::class);
-		$methodReflection
-			->method('getVariants')
-			->willReturn([new FunctionVariant(TemplateTypeMap::createEmpty(), TemplateTypeMap::createEmpty(), [], true, new UnionType([new ArrayType(new MixedType(), new MixedType()), new IterableType(new MixedType(), new ObjectType(ArrayHash::class))]))]);
-
-		$scope = $this->createMock(Scope::class);
-		$scope->method('getType')->willReturn(new ConstantBooleanType(false));
-
-		$methodCall = $this->createMock(MethodCall::class);
-		$methodCall->args = [];
-		$methodCall->method('getArgs')->willReturn($methodCall->args);
-
-		$resultType = $this->extension->getTypeFromMethodCall($methodReflection, $methodCall, $scope);
-
-		self::assertInstanceOf(ObjectType::class, $resultType);
-		self::assertSame(ArrayHash::class, $resultType->describe(VerbosityLevel::value()));
 	}
 
 }

--- a/tests/Type/Nette/data/FormContainerModel.php
+++ b/tests/Type/Nette/data/FormContainerModel.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace PHPStan\Type\Nette\Data\FormContainerModel;
+
+use Nette\Forms\Form;
+use function PHPStan\Testing\assertType;
+
+class Dto
+{
+	public string $name;
+	public string $value;
+
+	public function __construct(
+		string $name,
+		string $value
+	)
+	{
+		$this->name = $name;
+		$this->name = $value;
+	}
+}
+
+class FormContainerModel
+{
+	public function test()
+	{
+		$form = new Form();
+		$form->addText('name');
+		$form->addText('value');
+
+		$dto = $form->getValues(Dto::class);
+		$array = $form->getValues('array');
+
+		assertType(Dto::class, $dto);
+		assertType('array<string, mixed>', $array);
+	}
+}


### PR DESCRIPTION
This PR fixes an issue where if you want to map values into a DTO, you need to manually assert the type with assert instanceof.

This PR allows you to do `$values = $form->getValues(MyFormDto::class)` and the $values type will be properly typed.