### PR TITLE
Rename `Container::getUnsafeValues()` to `getUntrustedValues()`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -104,7 +104,7 @@ services:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 
 	-
-		class: PHPStan\Type\Nette\FormContainerUnsafeValuesDynamicReturnTypeExtension
+		class: PHPStan\Type\Nette\FormContainerUntrustedValuesDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 

--- a/src/Type/Nette/FormContainerUntrustedValuesDynamicReturnTypeExtension.php
+++ b/src/Type/Nette/FormContainerUntrustedValuesDynamicReturnTypeExtension.php
@@ -13,7 +13,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use function count;
 
-class FormContainerUnsafeValuesDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+class FormContainerUntrustedValuesDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
 
 	public function getClass(): string
@@ -23,19 +23,23 @@ class FormContainerUnsafeValuesDynamicReturnTypeExtension implements DynamicMeth
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool
 	{
-		return $methodReflection->getName() === 'getUnsafeValues';
+		return $methodReflection->getName() === 'getUntrustedValues' || $methodReflection->getName() === 'getUnsafeValues';
 	}
 
 	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
 	{
 		if (count($methodCall->getArgs()) === 0) {
-			return null;
+			return new ObjectType('Nette\Utils\ArrayHash');
 		}
 
 		$arg = $methodCall->getArgs()[0]->value;
 		$scopedType = $scope->getType($arg);
 		if ($scopedType->isNull()->yes()) {
 			return new ObjectType('Nette\Utils\ArrayHash');
+		}
+
+		if ($scopedType->isClassString()->yes()) {
+			return $scopedType->getClassStringObjectType();
 		}
 
 		if (count($scopedType->getConstantStrings()) === 1 && $scopedType->getConstantStrings()[0]->getValue() === 'array') {

--- a/tests/Type/Nette/FormContainerUntrustedValuesDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Nette/FormContainerUntrustedValuesDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Nette;
+
+use Composer\InstalledVersions;
+use OutOfBoundsException;
+use PHPStan\Testing\TypeInferenceTestCase;
+use function class_exists;
+use function version_compare;
+
+final class FormContainerUntrustedValuesDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+
+	public static function dataFileAsserts(): iterable
+	{
+		try {
+			$formsVersion = class_exists(InstalledVersions::class)
+				? InstalledVersions::getVersion('nette/forms')
+				: null;
+		} catch (OutOfBoundsException $e) {
+			$formsVersion = null;
+		}
+
+		if ($formsVersion === null || version_compare($formsVersion, '3.1.10', '<')) {
+			return;
+		}
+
+		yield from self::gatherAssertTypes(__DIR__ . '/data/FormContainerUntrustedValues.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/phpstan.neon',
+		];
+	}
+
+}

--- a/tests/Type/Nette/data/FormContainerUntrustedValues.php
+++ b/tests/Type/Nette/data/FormContainerUntrustedValues.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace PHPStan\Type\Nette\Data\FormContainerUntrustedValues;
+
+use Nette\Forms\Form;
+use Nette\Utils\ArrayHash;
+use function PHPStan\Testing\assertType;
+
+class Dto
+{
+	public string $name;
+	public string $value;
+
+	public function __construct(
+		string $name,
+		string $value
+	)
+	{
+		$this->name = $name;
+		$this->name = $value;
+	}
+}
+
+class FormContainerUntrustedValues
+{
+	public function test()
+	{
+		$form = new Form();
+		$form->addText('name');
+		$form->addText('value');
+
+		$dto = $form->getUntrustedValues(Dto::class);
+		$array = $form->getUntrustedValues('array');
+
+		assertType(Dto::class, $dto);
+		assertType('array<string, mixed>', $array);
+
+		assertType(ArrayHash::class, $form->getUntrustedValues());
+		assertType(ArrayHash::class, $form->getUntrustedValues(null));
+	}
+}


### PR DESCRIPTION
Mirroring the upstream change from 3.1.10: https://github.com/nette/forms/commit/fb2df3bfabf5f7ec11f622f8940d1e6e4d39582e

The new method also makes the `returnType` argument optional, defaulting to `ArrayHash`.

Also add handling of `returnType` taking `class-string`.

Finally, add tests based on `getValues()`.
