### PR TITLE
Add missing generics

### DIFF
--- a/stubs/Forms/Container.stub
+++ b/stubs/Forms/Container.stub
@@ -6,7 +6,7 @@ use Nette\Utils\ArrayHash;
 
 /**
  * @property   ArrayHash $values
- * @property-read \Iterator $controls
+ * @property-read \Iterator<array-key, mixed> $controls
  * @property-read Form|null $form
  * @phpstan-implements \ArrayAccess<string, \Nette\ComponentModel\IComponent>
  */


### PR DESCRIPTION
Maybe it can be more precise but I don't know a thing about nette so I'd like to avoid breaking thing and this is basically the same than before since unless I'm wrong `\Iterator = \Iterator<array-key, mixed>`.

This should fix the CI