### PR TITLE
Update test-expectations after more precise phpstan-src types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	],
 	"require": {
 		"php": "^7.4 || ^8.0",
-		"phpstan/phpstan": "^2.1.12"
+		"phpstan/phpstan": "^2.2.2"
 	},
 	"conflict": {
 		"nette/application": "<2.3.0",

--- a/tests/Type/Nette/data/strings-match.php
+++ b/tests/Type/Nette/data/strings-match.php
@@ -26,17 +26,17 @@ function (string $s): void {
 
 function (string $s): void {
 	$result = Strings::matchAll($s, '/ab(?P<num>\d+)(?P<suffix>ab)?/', PREG_SET_ORDER);
-	assertType("list<array{0: string, num: numeric-string, 1: numeric-string, suffix?: 'ab', 2?: 'ab'}>", $result);
+	assertType("list<array{0: string, num: decimal-int-string, 1: decimal-int-string, suffix?: 'ab', 2?: 'ab'}>", $result);
 };
 
 function (string $s): void {
 	$result = Strings::matchAll($s, '/ab(?P<num>\d+)(?P<suffix>ab)?/', PREG_PATTERN_ORDER);
-	assertType("array{0: list<string>, num: list<numeric-string>, 1: list<numeric-string>, suffix: list<''|'ab'>, 2: list<''|'ab'>}", $result);
+	assertType("array{0: list<string>, num: list<decimal-int-string>, 1: list<decimal-int-string>, suffix: list<''|'ab'>, 2: list<''|'ab'>}", $result);
 };
 
 function (string $s): void {
 	$result = Strings::matchAll($s, '/ab(?P<num>\d+)(?P<suffix>ab)?/', false, 0, false, true);
-	assertType("array{0: list<string>, num: list<numeric-string>, 1: list<numeric-string>, suffix: list<''|'ab'>, 2: list<''|'ab'>}", $result);
+	assertType("array{0: list<string>, num: list<decimal-int-string>, 1: list<decimal-int-string>, suffix: list<''|'ab'>, 2: list<''|'ab'>}", $result);
 };
 
 function (string $s): void {


### PR DESCRIPTION
required after https://github.com/phpstan/phpstan-src/pull/5793

~~merge after 2.2.2 got released (I decided against raising the min-phpstan version required for this package, as this would cut people still on 2.1.x off future updates for this 1st party extension)~~

I am already preparing [another PR which will require 2.2.2](https://github.com/phpstan/phpstan-nette/pull/201), so lets raise the min version